### PR TITLE
Improve code linke role and include CVL directive

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,6 +86,7 @@ add_module_names = False
 # -- codelink_extension configuration ----------------------------------------
 code_path_override = "../../code/"
 link_to_github = True
+path_remappings = {"@voting": "../../code/voting"}
 
 
 # -- todo extension configuration --------------------------------------------
@@ -100,6 +101,13 @@ spelling_word_list_filename = [
     "spelling_wordlist.txt",
     "packages_spelling_wordlist.txt",
 ]
+
+
+# -- graphviz configuration --------------------------------------------------
+# See https://www.sphinx-doc.org/en/master/usage/extensions/graphviz.html
+graphviz_output_format = "svg"  # Supports hover and links
+# For links, add ``target``, e.g. ``target="_blank"``.
+# See https://www.w3.org/TR/html401/types.html#type-frame-target for ``target`` options
 
 
 # -- add CVL syntax highlighting ---------------------------------------------

--- a/docs/source/features/githublink.md
+++ b/docs/source/features/githublink.md
@@ -1,1 +1,1 @@
-For example {clink}`Voting solution spec </voting/Voting_solution.spec>`.
+For example {clink}`Voting solution spec <@voting/Voting_solution.spec>`.

--- a/docs/source/features/githublink.rst
+++ b/docs/source/features/githublink.rst
@@ -1,1 +1,1 @@
-For example :clink:`Voting solution spec </voting/Voting_solution.spec>`.
+For example :clink:`Voting solution spec <@voting/Voting_solution.spec>`.

--- a/docs/source/features/includecvl.md
+++ b/docs/source/features/includecvl.md
@@ -1,4 +1,5 @@
 ```{cvlinclude} /../../code/voting/Voting_solution.spec
 :cvlobject: onlyLegalVotedChanges sumResultsEqualsTotalVotes numVoted
 :spacing: 1
+:caption:
 ```

--- a/docs/source/features/includecvl.rst
+++ b/docs/source/features/includecvl.rst
@@ -1,3 +1,4 @@
 .. cvlinclude:: /voting/Voting_solution.spec
-  :cvlobject: onlyLegalVotedChanges sumResultsEqualsTotalVotes numVoted
-  :spacing: 1
+   :cvlobject: onlyLegalVotedChanges sumResultsEqualsTotalVotes numVoted
+   :spacing: 1
+   :caption:

--- a/docs/source/features/includecvl.rst
+++ b/docs/source/features/includecvl.rst
@@ -1,3 +1,3 @@
-.. cvlinclude:: /../../code/voting/Voting_solution.spec
+.. cvlinclude:: /voting/Voting_solution.spec
   :cvlobject: onlyLegalVotedChanges sumResultsEqualsTotalVotes numVoted
   :spacing: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,7 +65,7 @@ Link to Github
 CVL syntax highlighting
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.. cvlinclude:: /../../code/voting/Voting_solution.spec
+.. cvlinclude:: /voting/Voting_solution.spec
    :cvlobject: methods
 
 Create pdf versions

--- a/docs/source/reference/codelink_extension.rst
+++ b/docs/source/reference/codelink_extension.rst
@@ -6,7 +6,8 @@
 Codelink extension
 ==================
 This is a Sphinx extension for linking source code files. The resulting links are either
-to local files, or to Github, depending on the configuration.
+to local files, or to Github, depending on the configuration,
+see :ref:`link_to_github_option`. 
 
 The code for this extension is at :mod:`docsinfra.sphinx_utils.codelink_extension`.
 
@@ -25,8 +26,17 @@ automatically by the :ref:`certora_doc_quickstart`.
    :end-before: sphinx.ext.graphviz
    :emphasize-lines: 2
 
+.. role:: python(code)
+   :language: python
+
 Options
 ^^^^^^^
+
+.. _link_to_github_option:
+
+``link_to_github``
+   Boolean, if true the links will be to the Github remote repository (deduced from
+   the repository of the path given in ``:clink:``). Otherwise will link to local files.
 
 .. _code_path_variable:
 
@@ -37,13 +47,21 @@ Options
    This options changes the absolute code path to the one given in ``code_path_override``.
    Note ``code_path_override`` must be relative to the source directory.
 
-``link_to_github``
-   Boolean, if true the links will be to the Github remote repository (deduced from
-   the repository of the path given in ``:clink:``). Otherwise will link to local files.
+.. _path_remappings_dict:
+
+``path_remappings``
+   Optional :python:`dict[str, str]`, where keys are identifiers starting with ``@`` and
+   values are paths relative to source directory ((i.e. the directory containing the
+   config file). Values which are absolute paths will also be considered as relative to
+   the source directory.
+
+   Paths in the ``:clink:`` role using these keys will be resolved using the provided
+   values. See :ref:`paths_resolution` for more information.
 
 
 Usage
 -----
+See :ref:`paths_resolution` for how paths are resolved.
 
 Syntax
 ^^^^^^

--- a/docs/source/reference/includecvl.rst
+++ b/docs/source/reference/includecvl.rst
@@ -39,20 +39,33 @@ Syntax
 
    .. cvlinclude:: <spec-file-path>
       :cvlobject: <rule-name> <another-rule-name> ...
-      :spacing: 2
+      :spacing: <spacing-number>
+      :language: <language-name>
+      :caption: <caption>
 
 ``spec-file-path``
-   Path to spec file. If relative should be relative to the current file.
-   If absolute, it will be considered as relative to the ``/source/`` directory.
+   The path to the file containing the code snippet. The path is resolved according
+   to the same :ref:`paths_resolution` used for the ``:clink:`` role.
 
 ``:cvlobject:``
-   A list of names of to include. Accepts rules, invariants and ghosts.
-   To include the methods block, add ``methods`` to this list.
+   Available only for spec files. A list of names of to include. Accepts rules,
+   invariants and ghosts. To include the methods block, add ``methods`` to this list.
    The source code for these elements will appear in the order they are given, including
    the documentation.
 
 ``:spacing:``
-   The number of lines between two elements, defaults to one.
+   The number of lines between two CVL elements. Applicable only to spec files and
+   directives using the ``:cvlobject:`` option. Defaults to one.
+
+``:language:``
+   Optional, the name of computer language for syntax highlighting.
+   For files with suffixes ``.spec``, ``.sol`` or ``.conf`` it is determined
+   automatically, see
+   :attr:`~docsinfra.sphinx_utils.includecvl.CVLInclude.file_suffix_to_language`.
+
+``:caption:``
+   Caption to use. If an empty caption is provided, the directive will use the default
+   caption, which is a code link to the file.
 
 In addition, this extension support all the options of the `literalinclude directive`_,
 such as ``:caption:`` and ``:emphasize-lines:``.
@@ -76,7 +89,7 @@ Example
    .. cvlinclude:: /voting/Voting_solution.spec
       :cvlobject: methods onlyLegalVotedChanges sumResultsEqualsTotalVotes
       :spacing: 2
-      :caption: Voting rules
+      :caption: :clink:`Voting rules</voting/Voting_solution.spec>`
       :emphasize-lines: 2
 
 .. card::
@@ -87,7 +100,7 @@ Example
    .. cvlinclude:: /voting/Voting_solution.spec
       :cvlobject: methods onlyLegalVotedChanges sumResultsEqualsTotalVotes
       :spacing: 2
-      :caption: Voting rules
+      :caption: :clink:`Voting rules</voting/Voting_solution.spec>`
       :emphasize-lines: 2
 
 

--- a/docs/source/reference/includecvl.rst
+++ b/docs/source/reference/includecvl.rst
@@ -73,7 +73,7 @@ Example
 
 .. code-block:: restructuredtext
 
-   .. cvlinclude:: /../../code/voting/Voting_solution.spec
+   .. cvlinclude:: /voting/Voting_solution.spec
       :cvlobject: methods onlyLegalVotedChanges sumResultsEqualsTotalVotes
       :spacing: 2
       :caption: Voting rules
@@ -84,7 +84,7 @@ Example
    Rendered as:
    ^^^^^^^^^^^^
 
-   .. cvlinclude:: /../../code/voting/Voting_solution.spec
+   .. cvlinclude:: /voting/Voting_solution.spec
       :cvlobject: methods onlyLegalVotedChanges sumResultsEqualsTotalVotes
       :spacing: 2
       :caption: Voting rules

--- a/docs/source/showcase/code_blocks/index.rst
+++ b/docs/source/showcase/code_blocks/index.rst
@@ -117,6 +117,55 @@ Inline CVL and solidity
 From external file
 ------------------
 
+Use the ``cvlinclude`` directive to include code snippets from files.
+
+Syntax
+^^^^^^
+
+.. code-block:: restructuredtext
+
+   .. cvlinclude:: path-to-file, see below
+      :language: language (optional), see below
+      :cvlobject: cvl objects to show, available only for spec files, see below
+      :spacing: <spacing-number>
+      :caption: caption (optional), see below
+      :lines: line-numbers of the snippet (optional)
+      :start-at: optional string marking the first line of included code
+      :start-after: optional string, the first line of the code starts after
+      :end-at: optional string marking the last line of included code
+      :end-before: optional string, the last line of the included code is before this
+
+path-to-file
+   The path to the file containing the code snippet. The path is resolved according
+   to the same :ref:`paths_resolution` used for the ``:clink:`` role.
+
+language
+   This is not needed for paths with suffixes ``.spec``, ``.sol`` or ``.conf``.
+   For these the appropriate language (i.e. CVL, Solidity and Json) will be used by
+   default.
+   See :attr:`~docsinfra.sphinx_utils.includecvl.CVLInclude.file_suffix_to_language`.
+
+cvlobject
+   See :ref:`including_cvl_elements` below.
+
+spacing-number
+   The number of lines between two CVL elements. Applicable only to spec files and
+   directives using the ``:cvlobject:`` option. Defaults to one.
+
+caption
+   If an empty caption is provided, the directive will use the default caption,
+   which is a code link to the file displaying the file's name, i.e.:
+
+   .. code-block:: restructuredtext
+
+      :clink:`file-name <path-to-file>`
+
+Note
+""""
+In addition ``cvlinclude`` supports all options supported by ``literalinclude``,
+see `literalinclude directive`_.
+
+
 .. _including_cvl_elements:
 
 Including CVL elements
@@ -165,19 +214,8 @@ Example
    Hooks are not supported (since they are not supported by the ``CVLDoc`` package).
    Use ``literalinclude`` below.
 
-Including any code
-^^^^^^^^^^^^^^^^^^
-Use the ``literalinclude`` directive to include code from an external file.
-As above, providing an absolute path is taken as relative to the ``/source/`` directory.
-For all possible options of ``literalinclude``, see the `literalinclude directive`_.
-
-.. important::
-
-   An alternative to using line numbers when including code are the
-   ``:start-after:``, ``:start-at:``, ``:end-before:``, and ``:end-at:`` options.
-   These accept string, which they match to find the desired lines.
-
-For example:
+Other Examples
+^^^^^^^^^^^^^^
 
 .. tab-set::
 
@@ -186,10 +224,10 @@ For example:
 
       .. code-block:: markdown
 
-         ```{literalinclude} ../../../../code/voting/Voting_solution.spec
-         :language: solidity
+         ```{cvlinclude} @voting/Voting.sol
          :lines: 4-
-         :emphasize-lines: 4-6
+         :emphasize-lines: 5-7
+         :caption:
          ```
 
    .. tab-item:: reStructuredText (.rst)
@@ -197,17 +235,17 @@ For example:
 
       .. code-block:: restructuredtext
 
-         .. literalinclude:: ../../../../code/voting/Voting.sol
-            :language: solidity
+         .. cvlinclude:: @voting/Voting.sol
             :lines: 4-
-            :emphasize-lines: 4-6
+            :emphasize-lines: 5-7
+            :caption:
 
 *Rendered as:*
       
-.. literalinclude:: ../../../../code/voting/Voting.sol
-   :language: solidity
+.. cvlinclude:: @voting/Voting.sol
    :lines: 4-
-   :emphasize-lines: 4-6
+   :emphasize-lines: 5-7
+   :caption:
 
 
 .. Links

--- a/docs/source/showcase/standard/index.rst
+++ b/docs/source/showcase/standard/index.rst
@@ -239,10 +239,38 @@ Link to a code file using the ``:clink:`` role.
 The link will be either to `GitHub`_ or to local file, depending on the value
 of ``link_to_github`` variable in the :file:`source/conf.py` file.
 
-Absolute paths will be considered as relative to the *absolute code path*
--- see :ref:`code_path_variable`. For complete documentation, see
-:ref:`codelink_extension`.
+.. _paths_resolution:
 
+Path resolution
+"""""""""""""""
+* Relative paths will be considered as relative to the current file (the file containing
+  the ``:clink:`` role).
+* Absolute paths will either:
+
+  #. Be considered as relative to the source folder, i.e. the folder containing
+     the :file:`conf.py` file -- if the :ref:`code_path_variable` has not been used.
+  #. Be considered as relative to the :ref:`code_path_variable`, if it has been set.
+
+* A path starting with ``@`` will be resolved according to the
+  :ref:`path_remappings_dict`. For example, suppose ``path_remappings`` is set
+  in the :file:`conf.py` file as:
+
+  .. literalinclude:: ../../conf.py
+     :language: python
+     :start-at: path_remappings
+     :end-at: path_remappings
+     :caption: conf.py
+
+  Then a link such as:
+
+  .. literalinclude:: ../../features/githublink.rst
+     :language: restructuredtext
+
+  Will be resolved as ``../../code/voting/Voting_solution.spec``
+  *relative to the source directory*.
+
+Syntax
+""""""
 The basic syntax is:
 
 .. tab-set::
@@ -255,6 +283,7 @@ The basic syntax is:
       
          {clink}`Optional name <relative-path-to-code-file>`
          {clink}`Optional name <absolute path relative to absolute code path>`
+         {clink}`Optional name <@remapping-key/path relative to remapping>`
 
    .. tab-item:: reStructuredText (.rst)
       :sync: rstKey
@@ -264,6 +293,7 @@ The basic syntax is:
       
          :clink:`Optional name <relative-path-to-code-file>`
          :clink:`Optional name <absolute path relative to absolute code path>`
+         :clink:`Optional name <@remapping-key/path relative to remapping>`
 
 For example:
 

--- a/docs/source/showcase/standard/links_code.md
+++ b/docs/source/showcase/standard/links_code.md
@@ -1,3 +1,4 @@
-* Reference to a folder: {clink}`Voting folder </voting>`
+* Reference to a folder: {clink}`Voting folder </voting>` using the `code_path_override`
 * Reference to a file: {clink}`Voting_solution.spec </voting/Voting_solution.spec>`
+* Reference using the remapping: {clink}`Optional name <@voting/Voting_solution.spec>`
 * Reference without text: {clink}`/voting/Voting_solution.spec`

--- a/docs/source/showcase/standard/links_code.rst
+++ b/docs/source/showcase/standard/links_code.rst
@@ -1,3 +1,4 @@
-* Reference to a folder: :clink:`Voting folder </voting>`
+* Reference to a folder: :clink:`Voting folder </voting>` using the ``code_path_override``
 * Reference to a file: :clink:`Voting_solution.spec </voting/Voting_solution.spec>`
+* Reference using the remapping: :clink:`Optional name <@voting/Voting_solution.spec>`
 * Reference without text: :clink:`/voting/Voting_solution.spec`

--- a/src/docsinfra/sphinx_utils/codelink_extension.py
+++ b/src/docsinfra/sphinx_utils/codelink_extension.py
@@ -24,12 +24,16 @@ _ROLE_NAME = "clink"
 
 class CodeLinkConfig:
     """
-    The configuration needed for code links.
+    The configuration needed for code links. Determines how paths are resolved,
+    see :meth:`~docsinfra.sphinx_utils.codelink_extension.CodeLinkConfig.relfn2path`.
 
     * Allows overriding the base path using ``code_path_override``.
     * Determine whether links are to github or local, using ``link_to_github``.
     * Enable creating path remappings using ``path_remappings`` dict. Each key
-      must start with ``@``, with values being paths (relative to the config file).
+      must start with ``@``, with values being paths relative to the source directory
+      (i.e. the directory containing the config file).
+      Values which are absolute paths will also be considered as relative to
+      the source directory.
       For example:
 
       .. code-block:: python
@@ -59,8 +63,23 @@ class CodeLinkConfig:
         """
         Similar to :meth:`BuildEnvironment.relfn2path`, returns a path relative to
         the documentation root and an absolute path. However this uses both the
-        ``code_path_override`` and the ``path_remappings``. See ``get_abs_path``
+        ``code_path_override`` and the ``path_remappings``.
+        See :meth:`~docsinfra.sphinx_utils.codelink_extension.CodeLinkConfig.get_abs_path`
         for examples.
+
+        * Relative paths will be considered as relative to the current file.
+        * Absolute paths will either:
+
+          #. Be considered as relative to the source folder (the folder containing
+             the :file:`conf.py` file) -- if
+             :attr:`~docsinfra.sphinx_utils.codelink_extension.CodeLinkConfig.is_codepath_overridden`
+             is ``False``.
+          #. Be considered as relative to the ``code_path_override`` -- if
+             :attr:`~docsinfra.sphinx_utils.codelink_extension.CodeLinkConfig.is_codepath_overridden`
+             is ``True``.
+
+        * A path starting with ``@`` will be resolved according to the
+          ``path_remappings`` dict.
         """
         pathobj = Path(filename)
 

--- a/src/docsinfra/sphinx_utils/codelink_extension.py
+++ b/src/docsinfra/sphinx_utils/codelink_extension.py
@@ -235,6 +235,7 @@ class TutorialsCodeLink(XRefRole):
             logger.warning(
                 __("could not create GitHub link for %s, falling back to local link")
                 % target,
+                location=(env.docname, self.lineno),
             )
 
         return title, path_link

--- a/src/docsinfra/sphinx_utils/codelink_extension.py
+++ b/src/docsinfra/sphinx_utils/codelink_extension.py
@@ -1,6 +1,7 @@
 """
 A Sphinx extension for linking source code files, either locally or to Github.
 """
+import os
 import re
 from pathlib import Path
 from typing import Any, Optional
@@ -24,24 +25,68 @@ _ROLE_NAME = "clink"
 class CodeLinkConfig:
     """
     The configuration needed for code links.
+
+    * Allows overriding the base path using ``code_path_override``.
+    * Determine whether links are to github or local, using ``link_to_github``.
+    * Enable creating path remappings using ``path_remappings`` dict. Each key
+      must start with ``@``, with values being paths (relative to the config file).
+      For example:
+
+      .. code-block:: python
+
+         path_remappings = {"@training-examples": "../../../training-examples"}
     """
 
     def __init__(self, env: BuildEnvironment):
         self._env = env
         self._link_to_github = env.config.link_to_github
         self._code_path_override = env.config.code_path_override
-
-        if self.is_codepath_overridden:
-            # Calculate the codepath relative to the source dir
-            # To use env.relfn2path we need an absolute path
-            codepath = self._code_path_override
-            if not codepath.startswith("/"):
-                codepath = "/" + codepath
-            self._code_path_override = Path(env.relfn2path(codepath)[1]).absolute()
+        self._path_remappings = env.config.path_remappings
 
     @property
     def is_codepath_overridden(self):
         return self._code_path_override is not None and self._code_path_override != ""
+
+    def get_remapping(self, key: str) -> Optional[str]:
+        if self._path_remappings is None:
+            return None
+        if (not key.startswith("@")) or (key not in self._path_remappings):
+            return None
+
+        return self._path_remappings[key]
+
+    def relfn2path(self, filename: str) -> tuple[str, str]:
+        """
+        Similar to :meth:`BuildEnvironment.relfn2path`, returns a path relative to
+        the documentation root and an absolute path. However this uses both the
+        ``code_path_override`` and the ``path_remappings``. See ``get_abs_path``
+        for examples.
+        """
+        pathobj = Path(filename)
+
+        def rel_to_srcdir(file: str) -> str:
+            """
+            when the file path needs to be relative to the source dir
+            (``self._env.srcdir``) we convert it to absolute.
+            """
+            if not file.startswith(os.path.sep):
+                return os.path.sep + file
+            return file
+
+        if filename.startswith("@"):
+            # Use remapping
+            key = pathobj.parts[0]
+            remap = rel_to_srcdir(self.get_remapping(key))
+            if remap is not None:
+                # Replace the key with the remapped value
+                filename = str(Path(remap, *pathobj.parts[1:]))
+        elif pathobj.is_absolute() and self.is_codepath_overridden:
+            # Use overridden code path as
+            relpathobj = pathobj.relative_to(os.path.sep)
+            override = rel_to_srcdir(self._code_path_override)
+            filename = str(Path(override) / relpathobj)
+
+        return self._env.relfn2path(filename)
 
     def get_abs_path(self, path: str) -> Path:
         """
@@ -52,15 +97,17 @@ class CodeLinkConfig:
         Examples:
 
         >>> codelinkconfig._code_path_override
-        PosixPath('/home/shoham/dev/docs-infrastructure/code')
-        >>> codelinkconfig.get_abs_path('voting/Voting_solution.spec')
-        PosixPath('/home/shoham/dev/docs-infrastructure/docs/source/voting/Voting_solution.spec')
-        """
-        pathobj = Path(path)
-        if (not self.is_codepath_overridden) or (not pathobj.is_absolute()):
-            return Path(self._env.relfn2path(path)[1]).absolute()
+        '../../code/'
+        >>> codelinkconfig.get_abs_path('/voting/Voting_solution.spec')
+        PosixPath('/home/shoham/dev/docs-infrastructure/code/voting/Voting_solution.spec')
 
-        return self._code_path_override / (pathobj.relative_to(pathobj.root))
+        >>> codelinkconfig.get_remapping("@voting")
+        '../../code/voting'
+        >>> codelinkconfig.get_abs_path('@voting/Voting_solution.spec')
+        PosixPath('/home/shoham/dev/docs-infrastructure/code/voting/Voting_solution.spec')
+        """
+        _, abspath = self.relfn2path(path)
+        return Path(abspath).absolute()
 
     @property
     def link_to_github(self) -> bool:
@@ -73,6 +120,7 @@ class CodeLinkConfig:
         """
         app.add_config_value("code_path_override", None, "env")
         app.add_config_value("link_to_github", True, "env")
+        app.add_config_value("path_remappings", None, "env")  # dict[str, str]
 
 
 class GithubUrlsMaker:
@@ -199,7 +247,7 @@ class TutorialsCodeLink(XRefRole):
         is_ref: bool,
     ) -> tuple[list[Node], list[system_message]]:
         """
-        Called before returning the finished nodes.  *node* is the reference
+        Called before returning the finished nodes. *node* is the reference
         node if one was created (*is_ref* is then true), else the content node.
         This method can add other nodes and must return a ``(nodes, messages)``
         tuple (the usual return value of a role function).

--- a/src/docsinfra/sphinx_utils/cvl2_lexer.py
+++ b/src/docsinfra/sphinx_utils/cvl2_lexer.py
@@ -82,12 +82,14 @@ class CVL2Lexer(RegexLexer):
 
     summaries = (
         r"\b(ALWAYS|CONSTANT|PER_CALLEE_CONSTANT|NONDET|HAVOC_ECF|HAVOC_ALL|"
-        r"DISPATCHER|AUTO)\b"
+        r"DISPATCHER|DISPATCH|AUTO)\b"
     )
     summaries_extra = r"\b(UNRESOLVED|ALL|DELETE)\b"
-    methods_block_keywords = r"\b(external|internal|returns|envfree|expect)\b"
+    methods_block_keywords = (
+        r"\b(external|internal|returns|optional|envfree|expect|default)\b"
+    )
 
-    hook_special_keywords = r"\b(Sstore|Sload|STORAGE|KEY)\b"
+    hook_special_keywords = r"\b(Sstore|Sload|STORAGE|KEY|INDEX)\b"
 
     solidity_keywords = (
         "calldata",
@@ -105,7 +107,7 @@ class CVL2Lexer(RegexLexer):
         "true",
     )
     cvl_imports = ("as", "import", "use", "using")
-    cvl_builtins = ("currentContract", "lastReverted", "lastStorage")
+    cvl_builtins = ("currentContract", "lastReverted", "lastStorage", "selector")
     cvl_assertions = ("assert", "satisfy")
     cvl_keywords = (
         "assuming",
@@ -263,7 +265,7 @@ class CVL2Lexer(RegexLexer):
             ),
             # Exit methods block
             (r"\}", Punctuation, "#pop"),
-            # Msic
+            # Misc
             include("constants"),
             include("defaults"),  # Lowest priority
         ],

--- a/src/docsinfra/sphinx_utils/includecvl.py
+++ b/src/docsinfra/sphinx_utils/includecvl.py
@@ -29,11 +29,12 @@ _INVALID_OPTIONS_PAIR = LiteralIncludeReader.INVALID_OPTIONS_PAIR + [
 # TODO: Hooks are currently ignored by cvldoc_parser, once fixed enable extracting them
 class CVLIncludeReader(LiteralIncludeReader):
     """
-    Extends LiteralIncludeReader by allowing to access CVL elements in spec files.
+    Extends :class:`sphinx.directives.code.LiteralIncludeReader` by allowing to
+    extract CVL elements in spec files by name.
 
     * By default, the language used is CVL.
-    * Currently does *not* support both ``diff`` and ``cvlobject`` (for showing the diff
-      for a particular object).
+    * Currently does *not* support both ``diff`` together with ``cvlobject``
+      (for showing the diff for a particular object).
     """
 
     INVALID_OPTIONS_PAIR = _INVALID_OPTIONS_PAIR
@@ -132,15 +133,25 @@ _extended_option_spec[CVLIncludeReader.SPACING] = int
 
 class CVLInclude(LiteralInclude):
     """
-    Extends LiteralInclude to enable including CVL elements.
-    To include cvl elements use the ``cvlobject`` option and provide a list of
-    CVL elements names, separated by spaces. To include the methods block use
-    ``methods``. Also adds the ``spacing`` option which determines the number of lines
-    between CVL elements.
+    Extends :class:`sphinx.directives.code.LiteralInclude`.
+
+    #. Enables including CVL elements by name. To include cvl elements by name use the
+       ``cvlobject`` option and provide a list of CVL elements names, separated by
+       spaces. To include the methods block use ``methods``.
+       Also adds the ``spacing`` option which determines the number of lines between CVL
+       elements.
+    #. Automatically determines the language for certain file extensions using the
+       :attr:`~docsinfra.sphinx_utils.includecvl.CVLInclude.file_suffix_to_language`
+       class variable.
+    #. Changes the default caption to use a code link (``:clink:`` role) to the
+       relevant file. The *default caption* is used whenever there is an empty
+       ``:caption:`` caption option.
     """
 
     option_spec = _extended_option_spec
-    _file_suffix_to_language = {".spec": "cvl", ".sol": "solidity", ".conf": "json"}
+
+    file_suffix_to_language = {".spec": "cvl", ".sol": "solidity", ".conf": "json"}
+    """ Default languages to use for these suffixes. """
 
     def _default_caption(self) -> str:
         """
@@ -173,8 +184,8 @@ class CVLInclude(LiteralInclude):
             # Set language based on extension
             if ("language" not in self.options) and ("diff" not in self.options):
                 suffix = Path(filename).suffix
-                if suffix in self._file_suffix_to_language:
-                    self.options["language"] = self._file_suffix_to_language[suffix]
+                if suffix in self.file_suffix_to_language:
+                    self.options["language"] = self.file_suffix_to_language[suffix]
 
             reader = CVLIncludeReader(filename, self.options, self.config)
             text, lines = reader.read(location=location)


### PR DESCRIPTION
### Adds the following improvements:

* Enables path remappings to be used in code link role, e.g. 
   ```restructuredtext
   :clink:`Optional title<@remapped/path-from-remap>`
   ```
* Makes `cvlinclude` directive use the same path resolution as `clink`
* `cvlinclude` has default languages for files with extensions `.spec`, `.sol` and `.conf`
* Default caption for `cvlinclude` is a `:clink:` to the relevant file.